### PR TITLE
Prevent crash on close

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.macFileDialogTest.xojo_uistate
 /Builds - macFileDialogTest
+.DS_Store

--- a/SaveOpenDialogs/NSSavePanelGTO.xojo_code
+++ b/SaveOpenDialogs/NSSavePanelGTO.xojo_code
@@ -74,11 +74,11 @@ Protected Class NSSavePanelGTO
 
 	#tag Method, Flags = &h0
 		Sub Destructor()
-		  #If TargetMacOS
-		    If mDelegateCache.HasKey(mPtr) Then
-		      mDelegateCache.Remove(mPtr)
-		    End If
-		  #EndIf
+		  ' #If TargetMacOS
+		  ' If mDelegateCache.HasKey(mPtr) Then
+		  ' mDelegateCache.Remove(mPtr)
+		  ' End If
+		  ' #EndIf
 		  
 		End Sub
 	#tag EndMethod
@@ -167,6 +167,10 @@ Protected Class NSSavePanelGTO
 	#tag Method, Flags = &h21
 		Private Sub Response(value as integer)
 		  #If TargetMacOS
+		    If mDelegateCache.HasKey(mPtr) Then
+		      mDelegateCache.Remove(mPtr)
+		    End If
+		    
 		    If Callback_ItemsSelected = Nil Then
 		      Return
 		    End If

--- a/Window1.xojo_window
+++ b/Window1.xojo_window
@@ -343,6 +343,8 @@ End
 		  
 		  label1.Text = "Option 1: " + SaveAccessories1.Option1Value.ToString + _
 		  " Option 2: " + SaveAccessories1.Option2Value.ToString
+		  
+		  mDialog = Nil
 		End Sub
 	#tag EndMethod
 


### PR DESCRIPTION
Fixes two issues
- Destructor causes crash on cancel (after 5 attempts)
- mDialog is left with a dangling reference after closure.